### PR TITLE
Feat: 카페 검색 범위 및 필터링 개선

### DIFF
--- a/src/hooks/useKakaoSearch.ts
+++ b/src/hooks/useKakaoSearch.ts
@@ -23,7 +23,10 @@ export const useKakaoSearch = () => {
     const ps = new window.kakao.maps.services.Places();
     ps.keywordSearch(keyword, (data: KakaoPlace[], status: string) => {
       if (status === window.kakao.maps.services.Status.OK) {
-        setResults(data);
+        const cafesOnly = data.filter((place: any) =>
+        place.category_group_code === 'CE7'
+      );
+      setResults(cafesOnly);
       } else {
         setResults([]);
       }

--- a/src/hooks/useKakaoSearch.ts
+++ b/src/hooks/useKakaoSearch.ts
@@ -12,6 +12,7 @@ export interface KakaoPlace {
 
 export const useKakaoSearch = () => {
   const [results, setResults] = useState<KakaoPlace[]>([]);
+  const location = new window.kakao.maps.LatLng(37.5556, 126.9369); 
 
   const search = (keyword: string) => {
     if (!keyword.trim()) {

--- a/src/hooks/useKakaoSearch.ts
+++ b/src/hooks/useKakaoSearch.ts
@@ -26,6 +26,11 @@ export const useKakaoSearch = () => {
       } else {
         setResults([]);
       }
+    },
+    {
+      location,
+      radius:3000,
+      sort: window.kakao.maps.services.SortBy.DISTANCE,
     });
   };
 


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?
close #63 
- `useKakaoSearch` 훅에 위치 기반 검색 옵션 추가
  - 신촌역 중심 좌표(lat: 37.5556, lng: 126.9369) 상수 추가
  - 반경 3km 이내 카페만 검색되도록 radius: 3000 설정
  - 거리순 정렬 (SortBy.DISTANCE) 적용
- `keywordSearch` 결과에서 카페(`CE7`) 카테고리만 필터링하여 약국, 학교 등 불필요한 장소 제거

## Why?

-

## How?

-

## Check List

- [X Merge 할 브랜치가 올바른가?
